### PR TITLE
ci: gate PyPI publish behind protected pypi environment

### DIFF
--- a/.github/workflows/_package-publish.yml
+++ b/.github/workflows/_package-publish.yml
@@ -7,6 +7,13 @@ on:
 jobs:
   package_publish:
     runs-on: ubuntu-latest
+    # `pypi` environment gates this job: it pauses on the v* tag until a required
+    # reviewer (a tme-studio admin, configured in repo Settings > Environments)
+    # approves. The OIDC id-token is only minted after approval, so a release
+    # triggered by anyone else cannot reach PyPI without an admin.
+    environment:
+      name: pypi
+      url: https://pypi.org/project/aignostics-tme-studio/
     permissions:
       contents: write
       packages: read


### PR DESCRIPTION
## What

Adds `environment: pypi` to the `package_publish` job so PyPI publishing pauses for a required-reviewer approval before the OIDC token is minted.

## Why

Publishing already uses OIDC trusted publishing (no stored secret). This adds the admin gate: only a designated reviewer (tme-studio admin) can approve a `v*`-tag publish, so a release triggered by anyone else can't reach PyPI.


No API key involved — OIDC only.