### PR TITLE
fix(ci): invoke cz via uv run in bump workflow

### DIFF
--- a/.github/workflows/bump.yml
+++ b/.github/workflows/bump.yml
@@ -51,8 +51,8 @@ jobs:
           # committing, tagging or pushing. If cz would fail (no bumpable commits,
           # bad --increment, version conflict), fail here — before any tag exists —
           # instead of leaving a half-bumped commit with no tag behind.
-          cz bump --dry-run --yes $BUMP_ARGS
-          cz bump --no-verify --yes $BUMP_ARGS
+          uv run cz bump --dry-run --yes $BUMP_ARGS
+          uv run cz bump --no-verify --yes $BUMP_ARGS
 
       - name: Update lockfile and amend bump commit
         run: |


### PR DESCRIPTION
## Why

The bump workflow failed with \`cz: command not found\`. \`commitizen\` is a dev dependency installed into \`.venv\` by \`mise run install\`; a bare \`cz\` call relies on the venv being on \`PATH\`, which isn't guaranteed per workflow step.

## What

Prefix both \`cz bump\` calls in \`bump.yml\` with \`uv run\`, matching how every other workflow invokes project tools (\`mise run\` / \`uv run\`).

Follow-up to #114.