### PR TITLE
fix(ci): unblock PyPI publish (keyring vs trusted publishing)

### DIFF
--- a/.github/workflows/_package-publish.yml
+++ b/.github/workflows/_package-publish.yml
@@ -45,8 +45,10 @@ jobs:
           fi
           echo "" >> RELEASE_NOTES.md
 
+      # --keyring-provider disabled overrides pyproject's `keyring-provider = "subprocess"`;
+      # uv refuses trusted publishing while any keyring provider is active.
       - name: Publish distribution to PyPI
-        run: uv publish --trusted-publishing always
+        run: uv publish --trusted-publishing always --keyring-provider disabled
 
       - name: Create GitHub release
         env:


### PR DESCRIPTION
Add `--keyring-provider disabled` to `uv publish`. uv refuses trusted publishing while pyproject's `keyring-provider = subprocess` is active, which failed the v0.4.0 publish. Nothing reached PyPI, so v0.4.0 is safe to re-release once this lands.

Follows #114, #115.