### PR TITLE
feat(notebooks): IDE immune-phenotype survival analysis from OpenTME WTR

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -87,3 +87,6 @@ profile.html
 
 
 # Application specific
+
+# marimo runtime cache
+__marimo__/

--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@ you have [access to OpenTME on Hugging Face](#hugging-face-access), and a [molab
     2. [Outlier detection](https://molab.marimo.io/github.com/aignostics/tme-studio/blob/main/src/aignostics_tme_studio/notebooks/examples/outlier_detection.py)
     3. [Survival analysis](https://molab.marimo.io/github.com/aignostics/tme-studio/blob/main/src/aignostics_tme_studio/notebooks/examples/survival_analysis.py)
     4. [Tumor immune phenotyping](https://molab.marimo.io/github.com/aignostics/tme-studio/blob/main/src/aignostics_tme_studio/notebooks/examples/tumor_immune_phenotyping.py)
+    5. [IDE from the whole tumor region vs. survival](https://molab.marimo.io/github.com/aignostics/tme-studio/blob/main/src/aignostics_tme_studio/notebooks/examples/ide_wtr_median.py)
 
 * **Demo:** contains a demo notebook showcasing all features in OpenTME and some example analyses.
     1. [Demo](https://molab.marimo.io/notebooks/nb_HKTV3XfnhNbsuPN1DwKZ3U/app)

--- a/src/aignostics_tme_studio/notebooks/examples/ide_wtr_median.py
+++ b/src/aignostics_tme_studio/notebooks/examples/ide_wtr_median.py
@@ -1,0 +1,425 @@
+import marimo
+
+__generated_with = "0.23.0"
+app = marimo.App(width="medium")
+
+
+@app.cell(hide_code=True)
+def _():
+    # Show logo
+    from aignostics_tme_studio.styling import styling_utils
+
+    styling_utils.get_aignx_logo()
+    return (styling_utils,)
+
+
+@app.cell(hide_code=True)
+def _(styling_utils):
+    styling_utils.load_css()
+
+
+@app.cell(hide_code=True)
+def _():
+    # Get Hugging Face token
+    import marimo as mo
+
+    _md = mo.md("""Enter your hugging face token in the below box to enable access to OpenTME.""")
+
+    _hf_instructions = """Create an access token by going to [hf.co/settings/tokens](https://hf.co/settings/tokens)
+        1. Go to "Repositories permissions".
+        2. Select "datasets/Aignostics/OpenTME" and check boxes for read and view access.
+        3. Click "create token". Enter your hugging face token in the below box to enable access to OpenTME.
+                         """
+    _acc = mo.accordion({"Click here for instructions to create a Hugging Face token": _hf_instructions})
+    hf_token = mo.ui.text(kind="password", label="Your HF Token from hf.co/settings/tokens")
+    mo.vstack([_md, _acc, hf_token])
+    return hf_token, mo
+
+
+@app.cell(hide_code=True)
+def _(mo):
+    mo.md(r"""
+    # IDE from the whole tumor region (median cut) 🎯
+
+    This notebook reproduces the tumor-immunology blog result
+    ([code](https://github.com/aignostics/ide-blog-post)): the **inflamed / excluded / desert (IDE)**
+    phenotype built from OpenTME's **whole-tumor-region (WTR)** zone readouts, tested against overall
+    survival across eight TCGA cohorts.
+
+    OpenTME resolves each slide into concentric zones (tumor core → inner margin → outer invasive
+    margin → extratumoral tissue) and reports a lymphocyte count and area per zone. We build two
+    densities straight from that geometry:
+
+    - lymphocyte density in the **tumor core** — lymphocytes that infiltrated the tumor itself.
+    - lymphocyte density in the **outer invasive margin** (the 500 μm band just outside the tumor) —
+      lymphocytes held at the tumor's leading edge.
+
+    ```python
+    lym_core   = df["CELL_DENSITY_LYMPHOCYTE_IN_TUMOR_CORE"]             # cells/mm² in the tumor core
+    lym_margin = df["CELL_DENSITY_LYMPHOCYTE_IN_OUTER_INVASIVE_MARGIN"]  # cells/mm² at the outer margin
+
+    core_thresh   = lym_core.median()                              # half the patients are inflamed
+    margin_thresh = lym_margin[lym_core <= core_thresh].median()   # split the rest 50/50
+
+    phenotype = np.where(lym_core   > core_thresh,   "inflamed",
+                np.where(lym_margin > margin_thresh, "excluded", "desert"))
+    ```
+
+    These densities live in OpenTME's `whole_tumor_region_cell_features_*` files. The tumor core is
+    cut at the cohort median (so half the patients are inflamed); the outer margin is then cut at its
+    median *within the non-inflamed patients*, giving a balanced 50 / 25 / 25 split. Both cuts are
+    fixed before survival is examined, so the log-rank p carries no cutpoint-selection bias. A patient's
+    slides are pooled by summed count / summed area, and a quality gate drops patients whose core or
+    margin band is below ~5 mm² (unreliable density). Survival endpoints are not part of OpenTME; we
+    link them by TCGA barcode and fetch harmonized overall survival from
+    [cBioPortal](https://www.cbioportal.org/).
+    """)
+
+
+@app.cell(hide_code=True)
+def _():
+    # Shared imports and the tumor-core / outer-margin density column names.
+    import pandas as pd
+    from huggingface_hub import hf_hub_download
+
+    from aignostics_tme_studio.plotting.tip_classification import IDE_COLORS
+    from aignostics_tme_studio.utils import cbioportal, config, ide, utils
+
+    ide_colors = IDE_COLORS  # lowercase alias so it can be passed between marimo cells
+    core_density = ide.LYMPHOCYTE_DENSITY_TUMOR_CORE
+    margin_density = ide.LYMPHOCYTE_DENSITY_OUTER_MARGIN
+    return (
+        cbioportal,
+        config,
+        core_density,
+        hf_hub_download,
+        ide,
+        ide_colors,
+        margin_density,
+        pd,
+        utils,
+    )
+
+
+@app.cell(hide_code=True)
+def _(config, mo):
+    _md = mo.md("""Select a TCGA indication, and the minimum trustworthy zone area (quality gate).""")
+    indication = mo.ui.dropdown(
+        options=list(config.CBIOPORTAL_STUDIES), value=config.DEFAULT_INDICATION, label="Indication"
+    )
+    # Drop patients whose pooled tumor-core or outer-margin band is below this area: a sub-mm² zone
+    # makes count/area density numerically unstable. 5 mm² removes the pathological tail.
+    min_area = mo.ui.slider(
+        start=0, stop=20, step=1, value=5, label="Min. zone area (mm²) quality gate", include_input=True
+    )
+    mo.vstack([_md, indication, min_area])
+    return indication, min_area
+
+
+@app.cell
+def _(
+    cbioportal,
+    config,
+    core_density,
+    hf_hub_download,
+    hf_token,
+    ide,
+    margin_density,
+    min_area,
+    pd,
+    utils,
+):
+    def build_cohort(indication_name):
+        """Load WTR features from HF, pool core/margin densities, join survival, cut at the median.
+
+        Returns the prepared patient-level dataframe, the IDE phenotype per patient, and the two
+        median thresholds used for the boundary lines.
+        """
+        # 1. Whole-tumor-region cell features, restricted to primary tumors.
+        path = hf_hub_download(
+            repo_id=config.REPO_ID,
+            filename=utils.get_wtr_cell_features_file_for_indication(indication_name),
+            repo_type="dataset",
+            token=hf_token.value or None,
+        )
+        slides = ide.restrict_to_primary_tumors(pd.read_csv(path))
+
+        # 2. Pool each patient's slides to one density per zone (summed count / summed area), rather
+        #    than averaging per-slide densities -- this is the correct area-weighted aggregation.
+        #    The min_area gate drops patients with a sub-threshold (unreliable) zone band.
+        patients = pd.DataFrame({
+            core_density: ide.pooled_zone_density(
+                slides, ide.LYMPHOCYTE_COUNT_TUMOR_CORE, core_density, min_area_mm2=min_area.value
+            ),
+            margin_density: ide.pooled_zone_density(
+                slides, ide.LYMPHOCYTE_COUNT_OUTER_MARGIN, margin_density, min_area_mm2=min_area.value
+            ),
+        }).reset_index()
+
+        # 3. Join harmonized overall survival and require complete data.
+        merged = patients.merge(
+            cbioportal.load_survival(config.CBIOPORTAL_STUDIES[indication_name]),
+            left_on="TCGA_CASE_ID",
+            right_on=cbioportal.PATIENT_ID_COLUMN,
+            how="inner",
+        )
+        prepared = ide.prepare_overall_survival(merged, [core_density, margin_density])
+
+        # 4. Pre-specified thresholds: core median, then outer-margin median WITHIN the non-inflamed
+        #    subset -> balanced 50/25/25 inflamed/excluded/desert. (Interactive sliders start here.)
+        core_median, margin_median = ide.median_thresholds(prepared[core_density], prepared[margin_density])
+        phenotype = ide.classify_two_threshold(
+            prepared[core_density], prepared[margin_density], core_median, margin_median
+        )
+        return prepared, phenotype, core_median, margin_median
+
+    return (build_cohort,)
+
+
+@app.cell
+def _(build_cohort, cbioportal, indication, mo):
+    df_ide, _, core_median, margin_median = build_cohort(indication.value)
+
+    mo.vstack([
+        mo.md(f"""**{len(df_ide)}** patients with WTR features and survival for `{indication.value}`
+        ({int(df_ide["event"].sum())} deaths)."""),
+        df_ide[
+            [
+                "TCGA_CASE_ID",
+                cbioportal.OS_MONTHS_COLUMN,
+                cbioportal.OS_STATUS_COLUMN,
+            ]
+        ].head(),
+    ])
+    return core_median, df_ide, margin_median
+
+
+@app.cell(hide_code=True)
+def _(core_density, core_median, df_ide, margin_density, margin_median, mo):
+    # Interactive controls: drag the two thresholds (default = cohort median), pick the survival
+    # comparison, and clip the follow-up window.
+    def _slider(series, default, label):
+        return mo.ui.slider(
+            start=float(series.min()),
+            stop=float(series.max()),
+            step=(float(series.max()) - float(series.min())) / 200 or 1e-6,
+            value=float(default),
+            label=label,
+            include_input=True,
+            full_width=True,
+        )
+
+    core_threshold = _slider(df_ide[core_density], core_median, "Tumor-core threshold (inflamed above)")
+    margin_threshold = _slider(df_ide[margin_density], margin_median, "Outer-margin threshold (excluded above)")
+    comparison = mo.ui.dropdown(
+        options=["Three groups", "inflamed vs rest", "excluded vs rest", "desert vs rest"],
+        value="Three groups",
+        label="Survival comparison",
+    )
+    clip_months = mo.ui.slider(
+        start=12, stop=120, step=12, value=120, label="Clip follow-up (months)", include_input=True
+    )
+
+    mo.vstack([
+        mo.md("### Controls"),
+        core_threshold,
+        margin_threshold,
+        mo.hstack([comparison, clip_months], justify="start", gap=2),
+    ])
+    return clip_months, comparison, core_threshold, margin_threshold
+
+
+@app.cell
+def _(core_density, core_threshold, df_ide, ide, margin_density, margin_threshold):
+    # Recompute the phenotype from the (possibly dragged) thresholds -- everything downstream reacts.
+    phenotype = ide.classify_two_threshold(
+        df_ide[core_density], df_ide[margin_density], core_threshold.value, margin_threshold.value
+    )
+    return (phenotype,)
+
+
+@app.cell
+def _(
+    core_density,
+    core_threshold,
+    df_ide,
+    ide,
+    ide_colors,
+    indication,
+    margin_density,
+    margin_threshold,
+    mo,
+    phenotype,
+):
+    import numpy as np
+    import plotly.graph_objects as go
+
+    _x, _y = df_ide[core_density], df_ide[margin_density]
+    _ct, _mt = core_threshold.value, margin_threshold.value
+    # Clip the view at the 99th percentile so a few extreme densities don't flatten the cloud.
+    _xmax = max(float(np.nanquantile(_x, 0.99)), _ct * 1.05)
+    _ymax = max(float(np.nanquantile(_y, 0.99)), _mt * 1.05)
+
+    def _rgba(hex_color, alpha):
+        h = hex_color.lstrip("#")
+        r, g, b = (int(h[i : i + 2], 16) for i in (0, 2, 4))
+        return f"rgba({r},{g},{b},{alpha})"
+
+    _fig = go.Figure()
+    _fig.update_layout(
+        title=f"{indication.value} — tumor core vs. outer invasive margin",
+        xaxis_title="Tumor-core lymphocytes (cells/mm²)",
+        yaxis_title="Outer-margin lymphocytes (cells/mm²)",
+        template="simple_white",
+        hovermode="closest",
+        hoverlabel={"namelength": -1},
+        xaxis_range=[0, _xmax],
+        yaxis_range=[0, _ymax],
+    )
+    # Faint phenotype-colored region backgrounds, drawn under the points.
+    _fig.add_shape(
+        type="rect",
+        x0=0,
+        x1=_ct,
+        y0=0,
+        y1=_mt,
+        layer="below",
+        line_width=0,
+        fillcolor=_rgba(ide_colors[ide.DESERT], 0.15),
+    )
+    _fig.add_shape(
+        type="rect",
+        x0=0,
+        x1=_ct,
+        y0=_mt,
+        y1=_ymax,
+        layer="below",
+        line_width=0,
+        fillcolor=_rgba(ide_colors[ide.EXCLUDED], 0.15),
+    )
+    _fig.add_shape(
+        type="rect",
+        x0=_ct,
+        x1=_xmax,
+        y0=0,
+        y1=_ymax,
+        layer="below",
+        line_width=0,
+        fillcolor=_rgba(ide_colors[ide.INFLAMED], 0.15),
+    )
+    # Core threshold spans the plot; the margin threshold only separates excluded/desert to its left.
+    _fig.add_shape(type="line", x0=_ct, x1=_ct, y0=0, y1=_ymax, line={"dash": "dash", "color": "#8a91a8", "width": 1})
+    _fig.add_shape(type="line", x0=0, x1=_ct, y0=_mt, y1=_mt, line={"dash": "dash", "color": "#8a91a8", "width": 1})
+    for _group in ide.IDE_PHENOTYPES:
+        _mask = phenotype == _group
+        _fig.add_scatter(
+            x=_x[_mask],
+            y=_y[_mask],
+            mode="markers",
+            name=f"{_group} (n={int(_mask.sum())})",
+            marker={"color": ide_colors[_group], "size": 6, "opacity": 0.8, "line_width": 0},
+            hovertemplate="tumor core %{x:.0f} cells/mm²<br>outer margin %{y:.0f} cells/mm²<extra></extra>",
+        )
+    mo.ui.plotly(_fig)
+
+
+@app.cell
+def _(comparison, df_ide, ide, ide_colors, pd, phenotype):
+    # Map the comparison choice to per-patient labels, colors, log-rank p and a Cox table.
+    _duration, _event = df_ide[ide.DURATION_COLUMN], df_ide[ide.EVENT_COLUMN]
+
+    if comparison.value == "Three groups":
+        labels = phenotype
+        label_colors = dict(ide_colors)
+        hr = ide.cox_hazard_ratios_vs_reference(phenotype, _duration, _event)
+        caption = "### Hazard ratios vs. inflamed (reference)"
+    else:
+        _target = comparison.value.split()[0]
+        labels = phenotype.where(phenotype == _target, "rest")
+        label_colors = {_target: ide_colors[_target], "rest": "#9aa0ae"}
+        _row = ide.cox_hazard_ratio(phenotype == _target, _duration, _event)
+        hr = pd.DataFrame({_target: _row}).T if _row else pd.DataFrame(columns=["hr", "ci_lower", "ci_upper", "p"])
+        caption = f"### Hazard ratio: {_target} vs. rest"
+
+    logrank_p = ide.three_group_logrank_pvalue(_duration, _event, labels)
+    return caption, hr, label_colors, labels, logrank_p
+
+
+@app.cell
+def _(caption, clip_months, df_ide, hr, ide, label_colors, labels, logrank_p, mo):
+    from lifelines import KaplanMeierFitter
+
+    from aignostics_tme_studio.plotting import kaplan_meier
+
+    _duration, _event = df_ide[ide.DURATION_COLUMN], df_ide[ide.EVENT_COLUMN]
+
+    def _fit(group):
+        mask = labels == group
+        return KaplanMeierFitter().fit(
+            durations=_duration[mask].clip(upper=clip_months.value),
+            event_observed=_event[mask],
+            label=f"{group} (n={int(mask.sum())})",
+        )
+
+    _order = [g for g in [*ide.IDE_PHENOTYPES, "rest"] if (labels == g).any()]
+    _color_map = {f"{g} (n={int((labels == g).sum())})": label_colors[g] for g in _order}
+    _figure = kaplan_meier.KaplanMeierPlotter(show_censors=True).render([_fit(g) for g in _order], color_map=_color_map)
+
+    _hr_table = (
+        hr.assign(**{"95% CI": hr.apply(lambda r: f"{r['ci_lower']:.2f}-{r['ci_upper']:.2f}", axis=1)})[
+            ["hr", "95% CI", "p"]
+        ].round(3)
+        if not hr.empty
+        else hr
+    )
+
+    _star = "★" if logrank_p < 0.05 else ""
+    mo.vstack([
+        mo.md(f"**Log-rank p = {logrank_p:.4f}** {_star} (follow-up clipped at {clip_months.value} months)"),
+        mo.ui.plotly(_figure),
+        mo.md(caption),
+        mo.md(_hr_table.to_markdown() if not _hr_table.empty else "_Too few patients/events for a stable estimate._"),
+    ])
+
+
+@app.cell(hide_code=True)
+def _(mo):
+    mo.md(r"""
+    ## Across cohorts
+
+    The headline result: the pre-specified median cut run across every indication, with a
+    Benjamini-Hochberg correction for testing them all at once. **★** marks log-rank p < 0.05.
+    Press the button to download and analyze every cohort.
+    """)
+    run_all = mo.ui.run_button(label="Run all indications")
+    run_all
+    return (run_all,)
+
+
+@app.cell
+def _(build_cohort, config, ide, mo, pd, run_all):
+    mo.stop(not run_all.value, mo.md("*Press the button above to compute the cross-cohort summary.*"))
+
+    def _summarize(indication_name):
+        cohort_df, cohort_phenotype, _, _ = build_cohort(indication_name)
+        return {
+            "cohort": indication_name,
+            "patients": len(cohort_df),
+            "events": int(cohort_df[ide.EVENT_COLUMN].sum()),
+            "logrank_p": ide.three_group_logrank_pvalue(
+                cohort_df[ide.DURATION_COLUMN], cohort_df[ide.EVENT_COLUMN], cohort_phenotype
+            ),
+        }
+
+    summary = pd.DataFrame([_summarize(name) for name in config.CBIOPORTAL_STUDIES]).set_index("cohort")
+    summary["q_value"] = ide.benjamini_hochberg(summary["logrank_p"])
+    summary["★"] = summary["logrank_p"].map(lambda p: "★" if p < 0.05 else "")
+
+    mo.vstack([
+        mo.md("### Three-group log-rank across cohorts (median WTR cut, BH-corrected)"),
+        mo.md(summary.round(4).to_markdown()),
+    ])
+
+
+if __name__ == "__main__":
+    app.run()

--- a/src/aignostics_tme_studio/notebooks/examples/ide_wtr_median.py
+++ b/src/aignostics_tme_studio/notebooks/examples/ide_wtr_median.py
@@ -23,17 +23,38 @@ def _():
     # Get Hugging Face token
     import marimo as mo
 
+    hf_token = mo.ui.text(kind="password", label="Your HF Token from hf.co/settings/tokens").form(
+        submit_button_label="Set token"
+    )
+    return hf_token, mo
+
+
+@app.cell(hide_code=True)
+def _(hf_token, mo):
     _md = mo.md("""Enter your hugging face token in the below box to enable access to OpenTME.""")
 
-    _hf_instructions = """Create an access token by going to [hf.co/settings/tokens](https://hf.co/settings/tokens)
-        1. Go to "Repositories permissions".
-        2. Select "datasets/Aignostics/OpenTME" and check boxes for read and view access.
-        3. Click "create token". Enter your hugging face token in the below box to enable access to OpenTME.
-                         """
-    _acc = mo.accordion({"Click here for instructions to create a Hugging Face token": _hf_instructions})
-    hf_token = mo.ui.text(kind="password", label="Your HF Token from hf.co/settings/tokens")
-    mo.vstack([_md, _acc, hf_token])
-    return hf_token, mo
+    _hf_instructions = mo.md("""
+        1. Go to [hf.co/settings/tokens](https://hf.co/settings/tokens) and click "+ Create new token",
+           choosing "Custom" preset.
+        2. Under "Repositories permissions", select `datasets/Aignostics/OpenTME` with read and view access.
+        3. Click "Create token" and paste the token below.
+    """)
+    _acc = mo.accordion({"How to create a Hugging Face token": _hf_instructions})
+
+    _token = (hf_token.value or "").strip()
+    token_valid = False
+    if not _token:
+        _status = mo.md("⚠️ No token set yet — paste it above and press **Set token**.")
+    else:
+        from huggingface_hub import whoami as _whoami
+
+        try:
+            _status = mo.md(f"✅ Token valid — authenticated as **{_whoami(token=_token)['name']}**.")
+            token_valid = True
+        except Exception:  # noqa: BLE001
+            _status = mo.md("❌ Token rejected by Hugging Face — check for typos or copied whitespace.")
+    mo.vstack([_md, _acc, hf_token, _status])
+    return (token_valid,)
 
 
 @app.cell(hide_code=True)
@@ -127,20 +148,27 @@ def _(
     margin_density,
     min_area,
     pd,
+    token_valid,
     utils,
 ):
+    from pathlib import Path
+
+    _cbioportal_cache = Path.home() / ".cache" / "tme-studio" / "cbioportal"
+
     def build_cohort(indication_name):
         """Load WTR features from HF, pool core/margin densities, join survival, cut at the median.
 
         Returns the prepared patient-level dataframe, the IDE phenotype per patient, and the two
         median thresholds used for the boundary lines.
         """
-        # 1. Whole-tumor-region cell features, restricted to primary tumors.
+        # 1. Whole-tumor-region cell features, restricted to primary tumors. Without a valid token,
+        #    serve only from the local HF cache (no network) instead of failing outright.
         path = hf_hub_download(
             repo_id=config.REPO_ID,
             filename=utils.get_wtr_cell_features_file_for_indication(indication_name),
             repo_type="dataset",
-            token=hf_token.value or None,
+            token=(hf_token.value or "").strip() if token_valid else None,
+            local_files_only=not token_valid,
         )
         slides = ide.restrict_to_primary_tumors(pd.read_csv(path))
 
@@ -158,7 +186,7 @@ def _(
 
         # 3. Join harmonized overall survival and require complete data.
         merged = patients.merge(
-            cbioportal.load_survival(config.CBIOPORTAL_STUDIES[indication_name]),
+            cbioportal.load_survival(config.CBIOPORTAL_STUDIES[indication_name], cache_dir=_cbioportal_cache),
             left_on="TCGA_CASE_ID",
             right_on=cbioportal.PATIENT_ID_COLUMN,
             how="inner",
@@ -177,10 +205,34 @@ def _(
 
 
 @app.cell
-def _(build_cohort, cbioportal, indication, mo):
-    df_ide, _, core_median, margin_median = build_cohort(indication.value)
+def _(build_cohort, cbioportal, indication, mo, token_valid):
+    # App mode hides tracebacks, so surface load failures in the UI and halt the cells below.
+    # Without a valid token this still works from the local cache; a cache miss pauses the notebook.
+    try:
+        df_ide, _, core_median, margin_median = build_cohort(indication.value)
+        _error = None
+    except Exception as _e:  # noqa: BLE001
+        _error = _e
+
+    mo.stop(
+        _error is not None and not token_valid,
+        mo.md("⏸️ Set a valid Hugging Face token above to load the cohort (no cached copy found)."),
+    )
+    mo.stop(
+        _error is not None,
+        mo.callout(
+            mo.md(
+                f"**Could not load `{indication.value}`.**\n\n"
+                f"`{type(_error).__name__}`: {_error}\n\n"
+                "If this is an authentication or 'gated repo' error, set a valid Hugging Face "
+                "token at the top of the notebook and re-run."
+            ),
+            kind="danger",
+        ),
+    )
 
     mo.vstack([
+        *([] if token_valid else [mo.md("⚠️ *No valid token — showing locally cached data.*")]),
         mo.md(f"""**{len(df_ide)}** patients with WTR features and survival for `{indication.value}`
         ({int(df_ide["event"].sum())} deaths)."""),
         df_ide[
@@ -385,20 +437,22 @@ def _(caption, clip_months, duration_clipped, event_clipped, hr, ide, label_colo
 
 @app.cell(hide_code=True)
 def _(mo):
-    mo.md(r"""
+    run_all = mo.ui.run_button(label="Run all indications")
+    mo.vstack([
+        mo.md(r"""
     ## Across cohorts
 
     The headline result: the pre-specified median cut run across every indication, with a
-    Benjamini-Hochberg correction for testing them all at once. **★** marks log-rank p < 0.05.
-    Press the button to download and analyze every cohort.
-    """)
-    run_all = mo.ui.run_button(label="Run all indications")
-    run_all
+    **Benjamini-Hochberg (BH)**  correction for testing them all at once. **★** marks log-rank p < 0.05.
+    Press the button to download and analyze every cohort (may take a few minutes on first run).
+    """),
+        run_all,
+    ])
     return (run_all,)
 
 
 @app.cell
-def _(build_cohort, config, ide, mo, pd, run_all):
+def _(build_cohort, config, ide, mo, pd, run_all, token_valid):
     mo.stop(not run_all.value, mo.md("*Press the button above to compute the cross-cohort summary.*"))
 
     def _summarize(indication_name):
@@ -412,11 +466,33 @@ def _(build_cohort, config, ide, mo, pd, run_all):
             ),
         }
 
-    summary = pd.DataFrame([_summarize(name) for name in config.CBIOPORTAL_STUDIES]).set_index("cohort")
+    try:
+        summary = pd.DataFrame([
+            _summarize(_name)
+            for _name in mo.status.progress_bar(
+                list(config.CBIOPORTAL_STUDIES),
+                title="Running all indications",
+                subtitle="Downloading WTR features and survival, then testing each cohort",
+            )
+        ]).set_index("cohort")
+        _error = None
+    except Exception as _e:  # noqa: BLE001
+        _error = _e
+
+    mo.stop(
+        _error is not None and not token_valid,
+        mo.md("⏸️ Set a valid Hugging Face token above — the local cache does not cover all cohorts."),
+    )
+    mo.stop(
+        _error is not None,
+        mo.callout(mo.md(f"**Cross-cohort run failed.** `{type(_error).__name__}`: {_error}"), kind="danger"),
+    )
+
     summary["q_value"] = ide.benjamini_hochberg(summary["logrank_p"])
     summary["★"] = summary["logrank_p"].map(lambda p: "★" if p < 0.05 else "")
 
     mo.vstack([
+        *([] if token_valid else [mo.md("⚠️ *No valid token — computed from locally cached data.*")]),
         mo.md("### Three-group log-rank across cohorts (median WTR cut, BH-corrected)"),
         mo.md(summary.round(4).to_markdown()),
     ])

--- a/src/aignostics_tme_studio/notebooks/examples/ide_wtr_median.py
+++ b/src/aignostics_tme_studio/notebooks/examples/ide_wtr_median.py
@@ -324,40 +324,41 @@ def _(
 
 
 @app.cell
-def _(comparison, df_ide, ide, ide_colors, pd, phenotype):
+def _(clip_months, comparison, df_ide, ide, ide_colors, pd, phenotype):
     # Map the comparison choice to per-patient labels, colors, log-rank p and a Cox table.
-    _duration, _event = df_ide[ide.DURATION_COLUMN], df_ide[ide.EVENT_COLUMN]
+    # Administrative censoring: events past the follow-up clip become censored at it.
+    _t = df_ide[ide.DURATION_COLUMN]
+    duration_clipped = _t.clip(upper=clip_months.value)
+    event_clipped = df_ide[ide.EVENT_COLUMN].where(_t <= clip_months.value, 0)
 
     if comparison.value == "Three groups":
         labels = phenotype
         label_colors = dict(ide_colors)
-        hr = ide.cox_hazard_ratios_vs_reference(phenotype, _duration, _event)
+        hr = ide.cox_hazard_ratios_vs_reference(phenotype, duration_clipped, event_clipped)
         caption = "### Hazard ratios vs. inflamed (reference)"
     else:
         _target = comparison.value.split()[0]
         labels = phenotype.where(phenotype == _target, "rest")
         label_colors = {_target: ide_colors[_target], "rest": "#9aa0ae"}
-        _row = ide.cox_hazard_ratio(phenotype == _target, _duration, _event)
+        _row = ide.cox_hazard_ratio(phenotype == _target, duration_clipped, event_clipped)
         hr = pd.DataFrame({_target: _row}).T if _row else pd.DataFrame(columns=["hr", "ci_lower", "ci_upper", "p"])
         caption = f"### Hazard ratio: {_target} vs. rest"
 
-    logrank_p = ide.three_group_logrank_pvalue(_duration, _event, labels)
-    return caption, hr, label_colors, labels, logrank_p
+    logrank_p = ide.three_group_logrank_pvalue(duration_clipped, event_clipped, labels)
+    return caption, duration_clipped, event_clipped, hr, label_colors, labels, logrank_p
 
 
 @app.cell
-def _(caption, clip_months, df_ide, hr, ide, label_colors, labels, logrank_p, mo):
+def _(caption, clip_months, duration_clipped, event_clipped, hr, ide, label_colors, labels, logrank_p, mo):
     from lifelines import KaplanMeierFitter
 
     from aignostics_tme_studio.plotting import kaplan_meier
 
-    _duration, _event = df_ide[ide.DURATION_COLUMN], df_ide[ide.EVENT_COLUMN]
-
     def _fit(group):
         mask = labels == group
         return KaplanMeierFitter().fit(
-            durations=_duration[mask].clip(upper=clip_months.value),
-            event_observed=_event[mask],
+            durations=duration_clipped[mask],
+            event_observed=event_clipped[mask],
             label=f"{group} (n={int(mask.sum())})",
         )
 
@@ -375,7 +376,7 @@ def _(caption, clip_months, df_ide, hr, ide, label_colors, labels, logrank_p, mo
 
     _star = "★" if logrank_p < 0.05 else ""
     mo.vstack([
-        mo.md(f"**Log-rank p = {logrank_p:.4f}** {_star} (follow-up clipped at {clip_months.value} months)"),
+        mo.md(f"**Log-rank p = {logrank_p:.4f}** {_star} (follow-up restricted to {clip_months.value} months)"),
         mo.ui.plotly(_figure),
         mo.md(caption),
         mo.md(_hr_table.to_markdown() if not _hr_table.empty else "_Too few patients/events for a stable estimate._"),

--- a/src/aignostics_tme_studio/utils/cbioportal.py
+++ b/src/aignostics_tme_studio/utils/cbioportal.py
@@ -1,0 +1,106 @@
+"""Fetch harmonized TCGA survival endpoints from the public cBioPortal REST API.
+
+OpenTME ships the spatial readouts but not the clinical outcomes. Overall survival is linked back to
+each slide through the TCGA barcode (the first 12 characters of ``TCGA_FILE_NAME`` equal the
+``TCGA_CASE_ID``, which in turn equals the cBioPortal ``patientId``). This module downloads the
+PATIENT-level clinical table for one or more studies, with retries and on-disk caching so a notebook
+can be re-run offline once the data has been fetched.
+"""
+
+import json
+import time
+from pathlib import Path
+
+import pandas as pd
+import requests
+
+from .config import CBIOPORTAL_API_URL, NEOADJUVANT_COLUMN
+
+PATIENT_ID_COLUMN = "patientId"
+OS_MONTHS_COLUMN = "OS_MONTHS"
+OS_STATUS_COLUMN = "OS_STATUS"
+
+_SURVIVAL_COLUMNS = [OS_MONTHS_COLUMN, OS_STATUS_COLUMN, NEOADJUVANT_COLUMN]
+_CLINICAL_DATA_PARAMS = {"clinicalDataType": "PATIENT", "projection": "SUMMARY"}
+_REQUEST_TIMEOUT_SECONDS = 180
+
+
+def _request_with_retries(url: str, params: dict, *, tries: int = 6, backoff_seconds: float = 3.0) -> requests.Response:
+    """Perform a GET request, retrying transient failures with linear backoff.
+
+    Args:
+        url: The endpoint to request.
+        params: Query parameters for the request.
+        tries: Maximum number of attempts before giving up.
+        backoff_seconds: Base wait; attempt ``i`` sleeps ``backoff_seconds * (i + 1)`` on failure.
+
+    Returns:
+        The successful HTTP response.
+
+    Raises:
+        requests.RequestException: If all attempts fail.
+        RuntimeError: Defensive guard; unreachable while ``tries >= 1``.
+    """
+    for attempt in range(tries):
+        try:
+            response = requests.get(url, params=params, timeout=_REQUEST_TIMEOUT_SECONDS)
+            response.raise_for_status()
+            return response
+        except requests.RequestException:
+            if attempt == tries - 1:
+                raise
+            time.sleep(backoff_seconds * (attempt + 1))
+    msg = "Unreachable: retry loop exited without returning or raising."  # pragma: no cover
+    raise RuntimeError(msg)  # pragma: no cover
+
+
+def _load_study_clinical_data(study: str, cache_dir: Path | None) -> list[dict]:
+    """Return the raw PATIENT clinical records for a single study, using the cache when available.
+
+    Args:
+        study: The cBioPortal study identifier (e.g. ``blca_tcga_pan_can_atlas_2018``).
+        cache_dir: Directory to read/write the cached JSON, or ``None`` to skip caching.
+
+    Returns:
+        The list of clinical-data records as returned by the cBioPortal API.
+    """
+    cache_file = cache_dir / f"{study}.json" if cache_dir is not None else None
+    if cache_file is not None and cache_file.exists():
+        return json.loads(cache_file.read_text(encoding="utf-8"))
+
+    url = f"{CBIOPORTAL_API_URL}/studies/{study}/clinical-data"
+    data = _request_with_retries(url, _CLINICAL_DATA_PARAMS).json()
+
+    if cache_file is not None:
+        cache_dir.mkdir(parents=True, exist_ok=True)
+        cache_file.write_text(json.dumps(data), encoding="utf-8")
+    return data
+
+
+def load_survival(studies: list[str], cache_dir: str | Path | None = None) -> pd.DataFrame:
+    """Load patient-level overall-survival data for one or more cBioPortal studies.
+
+    Records from multiple studies are concatenated, so pooling e.g. LUAD and LUSC into a single lung
+    cohort is a matter of passing both study ids.
+
+    Args:
+        studies: One or more cBioPortal study identifiers to fetch and concatenate.
+        cache_dir: Optional directory for caching the raw API responses between runs.
+
+    Returns:
+        A dataframe with one row per patient and the columns ``patientId``, ``OS_MONTHS``,
+        ``OS_STATUS`` and (when present) the neoadjuvant-history flag.
+    """
+    cache_path = Path(cache_dir) if cache_dir is not None else None
+
+    frames = []
+    for study in studies:
+        records = _load_study_clinical_data(study, cache_path)
+        pivoted = pd.DataFrame(records).pivot_table(
+            index=PATIENT_ID_COLUMN, columns="clinicalAttributeId", values="value", aggfunc="first"
+        )
+        frames.append(pivoted)
+
+    combined = pd.concat(frames)
+    available = [column for column in _SURVIVAL_COLUMNS if column in combined.columns]
+    return combined[available].reset_index()

--- a/src/aignostics_tme_studio/utils/config.py
+++ b/src/aignostics_tme_studio/utils/config.py
@@ -4,11 +4,35 @@ REPO_ID = "aignostics/OpenTME"
 
 TISSUE_FEATURES_FILES = "data/{}/tme_features_{}_RUO.csv"
 
+# Whole-tumor-region cell features (concentric-zone readouts: tumor core, inner/outer invasive
+# margin, extratumoral tissue), used by the IDE immune-phenotype analysis.
+WHOLE_TUMOR_REGION_CELL_FEATURES_FILES = "data/{}/whole_tumor_region_cell_features_{}_RUO.csv"
+
 INDICATIONS = ["bladder_cancer", "breast_cancer", "lung_cancer", "colorectal_cancer", "liver_cancer"]
 
 THUMBNAIL_FILES = ["wsi.png", "tissue_qc.png", "tissue_segmentation.png", "cell_classification.png"]
 
 DEFAULT_INDICATION = INDICATIONS[0]
+
+# cBioPortal public REST API, used to fetch harmonized TCGA overall-survival endpoints that are not
+# shipped with OpenTME (see the `survival_analysis` and `ide_immune_phenotypes` example notebooks).
+CBIOPORTAL_API_URL = "https://www.cbioportal.org/api"
+
+# Column carrying the neoadjuvant-treatment history flag in cBioPortal PATIENT clinical data.
+NEOADJUVANT_COLUMN = "HISTORY_NEOADJUVANT_TRTYN"
+
+# Map each OpenTME indication to the TCGA PanCancer Atlas study id(s) on cBioPortal. Lung pools the
+# adenocarcinoma (LUAD) and squamous-cell (LUSC) cohorts, matching the OpenTME `lung_cancer` features.
+CBIOPORTAL_STUDIES = {
+    "bladder_cancer": ["blca_tcga_pan_can_atlas_2018"],
+    "breast_cancer": ["brca_tcga_pan_can_atlas_2018"],
+    "lung_cancer": ["luad_tcga_pan_can_atlas_2018", "lusc_tcga_pan_can_atlas_2018"],
+    "colorectal_cancer": ["coadread_tcga_pan_can_atlas_2018"],
+    "liver_cancer": ["lihc_tcga_pan_can_atlas_2018"],
+    "pancreatic_cancer": ["paad_tcga_pan_can_atlas_2018"],
+    "prostate_cancer": ["prad_tcga_pan_can_atlas_2018"],
+    "stomach_cancer": ["stad_tcga_pan_can_atlas_2018"],
+}
 
 MODEL_SETTINGS_FILENAME = "settings/model_variables.yaml"
 FEAT_SETTINGS_FILENAME = "settings/tme_features.yaml"

--- a/src/aignostics_tme_studio/utils/ide.py
+++ b/src/aignostics_tme_studio/utils/ide.py
@@ -1,12 +1,12 @@
 """Inflamed / excluded / desert (IDE) immune-phenotype survival analysis on OpenTME features.
 
-Reproduces the tumor-immunology blog analysis: a two-threshold rule on lymphocyte density (in
-carcinoma vs. stroma) partitions patients into the three immune phenotypes, which are then tested
-against overall survival with a three-group log-rank test and pairwise Cox models against the
-inflamed (infiltrated) reference.
+Reproduces the tumor-immunology blog analysis: a two-threshold rule on lymphocyte density (in the
+tumor core vs. the outer invasive margin) partitions patients into the three immune phenotypes,
+which are then tested against overall survival with a three-group log-rank test and pairwise Cox
+models against the inflamed (infiltrated) reference.
 
 The pipeline is deliberately small and side-effect free so it can be unit tested and reused across
-the ``ide_immune_phenotyping`` notebook and any downstream scans:
+the ``ide_wtr_median`` notebook and any downstream scans:
 
     1. :func:`restrict_to_primary_tumors` - keep primary solid tumors only.
     2. :func:`aggregate_slides_to_patient` - average a patient's slides to one profile.

--- a/src/aignostics_tme_studio/utils/ide.py
+++ b/src/aignostics_tme_studio/utils/ide.py
@@ -1,0 +1,330 @@
+"""Inflamed / excluded / desert (IDE) immune-phenotype survival analysis on OpenTME features.
+
+Reproduces the tumor-immunology blog analysis: a two-threshold rule on lymphocyte density (in
+carcinoma vs. stroma) partitions patients into the three immune phenotypes, which are then tested
+against overall survival with a three-group log-rank test and pairwise Cox models against the
+inflamed (infiltrated) reference.
+
+The pipeline is deliberately small and side-effect free so it can be unit tested and reused across
+the ``ide_immune_phenotyping`` notebook and any downstream scans:
+
+    1. :func:`restrict_to_primary_tumors` - keep primary solid tumors only.
+    2. :func:`aggregate_slides_to_patient` - average a patient's slides to one profile.
+    3. :func:`prepare_overall_survival` - parse survival, drop neoadjuvant-pretreated cases.
+    4. :func:`three_group_logrank_pvalue` / :func:`cox_hazard_ratios_vs_reference` - the tests.
+"""
+
+import numpy as np
+import pandas as pd
+from lifelines import CoxPHFitter
+from lifelines.statistics import multivariate_logrank_test
+
+from .cbioportal import OS_MONTHS_COLUMN, OS_STATUS_COLUMN
+from .config import NEOADJUVANT_COLUMN
+
+# TCGA barcode: TCGA-<tss>-<patient>-<sample-type><vial>-...; the 4th block's leading two digits are
+# the sample-type code (01=primary solid tumor, 02=recurrent, 06=metastatic, 11=solid normal).
+PRIMARY_TUMOR_SAMPLE_TYPE_CODE = "01"
+_SAMPLE_TYPE_PATTERN = r"^TCGA-[^-]+-[^-]+-(\d{2})"
+
+DURATION_COLUMN = "duration"
+EVENT_COLUMN = "event"
+
+INFLAMED = "inflamed"
+EXCLUDED = "excluded"
+DESERT = "desert"
+IDE_PHENOTYPES = (INFLAMED, EXCLUDED, DESERT)
+
+# OpenTME whole-tumor-region (WTR) lymphocyte readouts used by the blog's core-vs-margin IDE rule
+# (found in the ``whole_tumor_region_cell_features_*`` files). Densities are in cells/mm²; the paired
+# counts let us pool slides -> patient by summed count / summed area (see pooled_zone_density).
+LYMPHOCYTE_DENSITY_TUMOR_CORE = "CELL_DENSITY_LYMPHOCYTE_IN_TUMOR_CORE"
+LYMPHOCYTE_DENSITY_OUTER_MARGIN = "CELL_DENSITY_LYMPHOCYTE_IN_OUTER_INVASIVE_MARGIN"
+LYMPHOCYTE_COUNT_TUMOR_CORE = "CELL_COUNT_LYMPHOCYTE_IN_TUMOR_CORE"
+LYMPHOCYTE_COUNT_OUTER_MARGIN = "CELL_COUNT_LYMPHOCYTE_IN_OUTER_INVASIVE_MARGIN"
+
+# Minimum group size for a Cox model to be reported; below this the estimate is too unstable.
+_MIN_COX_GROUP_SIZE = 8
+
+
+def restrict_to_primary_tumors(df: pd.DataFrame, file_name_column: str = "TCGA_FILE_NAME") -> pd.DataFrame:
+    """Keep only primary solid tumor slides, dropping recurrent/metastatic/normal samples.
+
+    Several cohorts carry stray non-primary slides whose non-tumor tissue or pre/post-treatment
+    effects would confound the immune-phenotype survival readout.
+
+    Args:
+        df: Slide-level OpenTME features including the TCGA file-name column.
+        file_name_column: Name of the column holding the TCGA barcode / file name.
+
+    Returns:
+        The subset of ``df`` whose sample-type code is primary solid tumor (``01``).
+    """
+    sample_type_code = df[file_name_column].astype(str).str.extract(_SAMPLE_TYPE_PATTERN)[0]
+    return df[sample_type_code == PRIMARY_TUMOR_SAMPLE_TYPE_CODE]
+
+
+def aggregate_slides_to_patient(df: pd.DataFrame, case_id_column: str = "TCGA_CASE_ID") -> pd.DataFrame:
+    """Collapse multiple slides per patient into a single profile.
+
+    Numeric features are averaged across the patient's slides; non-numeric columns take the first
+    value. Aggregating to the patient before any statistics ensures that patients, not slides, are
+    the unit of analysis.
+
+    Args:
+        df: Slide-level features containing the case-id column.
+        case_id_column: Name of the column identifying the patient (TCGA case id).
+
+    Returns:
+        One row per patient with averaged numeric features.
+    """
+    numeric_columns = df.select_dtypes("number").columns.tolist()
+    other_columns = [c for c in df.columns if c not in numeric_columns and c != case_id_column]
+
+    # Aggregate numeric and non-numeric blocks separately, then join once. Building the result with a
+    # single concat avoids the column-by-column insertion that fragments wide OpenTME frames (which
+    # can carry thousands of columns) and triggers pandas' PerformanceWarning.
+    grouped = df.groupby(case_id_column, sort=False)
+    # .copy() de-fragments the concatenated block manager before reset_index inserts the key column,
+    # avoiding pandas' PerformanceWarning on very wide OpenTME frames (thousands of columns).
+    aggregated = pd.concat([grouped[numeric_columns].mean(), grouped[other_columns].first()], axis=1).copy()
+    return aggregated.reset_index()
+
+
+def prepare_overall_survival(df: pd.DataFrame, feature_columns: list[str]) -> pd.DataFrame:
+    """Parse overall survival, drop neoadjuvant-pretreated cases, and require complete features.
+
+    ``OS_STATUS`` arrives as ``"1:DECEASED"`` / ``"0:LIVING"``; the leading integer is the event
+    indicator and ``OS_MONTHS`` the follow-up time. Cases imaged after neoadjuvant therapy are
+    removed so pre/post-treatment tissue cannot confound the readout.
+
+    Args:
+        df: Patient-level features already merged with cBioPortal survival columns.
+        feature_columns: Feature columns that must be non-null for a patient to be included.
+
+    Returns:
+        A copy of ``df`` with numeric ``duration`` and ``event`` columns and complete data.
+    """
+    prepared = df.dropna(subset=[OS_MONTHS_COLUMN, OS_STATUS_COLUMN, *feature_columns]).copy()
+
+    if NEOADJUVANT_COLUMN in prepared.columns:
+        neoadjuvant = prepared[NEOADJUVANT_COLUMN].astype(str).str.startswith("Yes")
+        prepared = prepared[~neoadjuvant].copy()
+
+    prepared[DURATION_COLUMN] = pd.to_numeric(prepared[OS_MONTHS_COLUMN], errors="coerce")
+    prepared[EVENT_COLUMN] = prepared[OS_STATUS_COLUMN].astype(str).str.split(":").str[0].astype(int)
+    return prepared.dropna(subset=[DURATION_COLUMN])
+
+
+def pooled_zone_density(
+    df: pd.DataFrame,
+    count_column: str,
+    density_column: str,
+    case_id_column: str = "TCGA_CASE_ID",
+    min_area_mm2: float = 0.0,
+) -> pd.Series:
+    """Pool a zone's per-slide lymphocyte density to one value per patient by area-weighting.
+
+    Averaging per-slide densities over-weights small slides. Instead we recover each slide's zone
+    area as ``count / density`` and take ``sum(count) / sum(area)`` across the patient's slides -- the
+    same slides->patient pooling the blog performs from raw counts and areas. Slides with no
+    lymphocytes contribute a zero count (their area is unrecoverable from a zero density and is
+    dropped); a patient whose slides are all lymphocyte-free gets a density of zero.
+
+    A quality gate drops patients whose pooled zone area is below ``min_area_mm2``: a sub-mm² band
+    makes ``count / area`` numerically unstable (a handful of cells implies an enormous density) and
+    can spuriously flip a patient's phenotype. Such patients are returned as NaN so downstream
+    ``prepare_overall_survival`` excludes them.
+
+    Args:
+        df: Slide-level features with the zone's count and density columns and a case-id column.
+        count_column: Lymphocyte count column for the zone.
+        density_column: Lymphocyte density column for the zone (cells/mm²).
+        case_id_column: Column identifying the patient.
+        min_area_mm2: Minimum pooled zone area (mm²) required to trust the density; 0 disables the gate.
+
+    Returns:
+        Per-patient pooled density, indexed by ``case_id_column`` (NaN where the area gate fails).
+    """
+    slide_area = df[count_column] / df[density_column].replace(0, np.nan)  # cells / (cells/mm²) = mm²
+    grouped = pd.DataFrame({
+        case_id_column: df[case_id_column].to_numpy(),
+        "_count": df[count_column].to_numpy(),
+        "_area": slide_area.to_numpy(),
+    }).groupby(case_id_column)
+    total_count = grouped["_count"].sum(min_count=1)
+    total_area = grouped["_area"].sum(min_count=1)
+    density = total_count / total_area
+    density = density.where(total_area >= min_area_mm2, np.nan)  # drop untrustworthy sub-min-area zones
+    return density.mask(total_count == 0, 0.0)  # lymphocyte-free -> density 0 (kept), not 0/0=NaN
+
+
+def zone_lymphocyte_density(df: pd.DataFrame, count_column: str, area_column: str) -> pd.Series:
+    """Compute per-patient lymphocyte density (cells/mm²) for a whole-tumor-region zone.
+
+    A convenience for deriving density from a zone's lymphocyte count and area when a ready-made
+    ``CELL_DENSITY_LYMPHOCYTE_IN_<zone>`` column is not available. Because a patient's slides are
+    averaged beforehand, dividing the mean count by the mean area equals pooling across slides.
+
+    Args:
+        df: Patient-level features containing the zone count and area columns.
+        count_column: Column with the lymphocyte count in the zone.
+        area_column: Column with the zone's absolute area (μm²); the result carries the input units.
+
+    Returns:
+        The lymphocyte density per patient, aligned to ``df``'s index.
+    """
+    return df[count_column] / df[area_column]
+
+
+def classify_two_threshold(
+    primary: pd.Series,
+    secondary: pd.Series,
+    primary_threshold: float,
+    secondary_threshold: float,
+) -> pd.Series:
+    """Apply the two-threshold IDE rule to any pair of infiltration features.
+
+    The rule reads top-down: above the ``primary`` threshold is *inflamed*; otherwise above the
+    ``secondary`` threshold is *excluded*; otherwise *desert*. For the whole-tumor-region variant the
+    primary axis is tumor-core density and the secondary is outer-invasive-margin density.
+
+    Args:
+        primary: Primary infiltration feature (e.g. tumor-core lymphocyte density).
+        secondary: Secondary feature checked only when the primary threshold is not met.
+        primary_threshold: Cutpoint on the primary feature (inflamed above it).
+        secondary_threshold: Cutpoint on the secondary feature (excluded above it).
+
+    Returns:
+        The IDE phenotype label per patient, aligned to ``primary``'s index.
+    """
+    phenotype = np.where(
+        primary > primary_threshold,
+        INFLAMED,
+        np.where(secondary > secondary_threshold, EXCLUDED, DESERT),
+    )
+    return pd.Series(phenotype, index=primary.index)
+
+
+def median_thresholds(primary: pd.Series, secondary: pd.Series) -> tuple[float, float]:
+    """Pre-specified IDE cutpoints: primary median, then secondary median within the non-inflamed set.
+
+    The primary (tumor-core) threshold is the cohort median, so exactly half the patients are
+    inflamed. The secondary (outer-margin) threshold is the median **among the non-inflamed**
+    patients (primary <= core threshold), so the remaining half splits evenly into excluded and
+    desert -- a balanced 50 / 25 / 25 partition. Both cuts are fixed before survival is examined
+    (the secondary median is defined purely by the primary split), so the log-rank carries no
+    cutpoint-selection bias.
+
+    Args:
+        primary: Primary infiltration feature (tumor-core lymphocyte density).
+        secondary: Secondary feature (outer-margin lymphocyte density).
+
+    Returns:
+        The ``(primary_threshold, secondary_threshold)`` pair.
+    """
+    primary_threshold = float(primary.median())
+    non_inflamed = primary <= primary_threshold
+    secondary_threshold = float(secondary[non_inflamed].median())
+    return primary_threshold, secondary_threshold
+
+
+def three_group_logrank_pvalue(duration: pd.Series, event: pd.Series, phenotype: pd.Series) -> float:
+    """Return the p-value of the three-group (inflamed/excluded/desert) log-rank test.
+
+    Args:
+        duration: Follow-up time per patient.
+        event: Event indicator per patient (1 = death, 0 = censored).
+        phenotype: IDE phenotype label per patient.
+
+    Returns:
+        The log-rank p-value across the three phenotype groups.
+    """
+    return float(multivariate_logrank_test(duration, phenotype, event).p_value)
+
+
+def cox_hazard_ratio(group: pd.Series, duration: pd.Series, event: pd.Series) -> dict | None:
+    """Fit a Cox model for a binary group indicator and return its hazard ratio.
+
+    Args:
+        group: Boolean/0-1 membership per patient (the group whose risk is estimated).
+        duration: Follow-up time per patient.
+        event: Event indicator per patient (1 = death, 0 = censored).
+
+    Returns:
+        A mapping with ``hr``, ``ci_lower``, ``ci_upper`` and ``p``, or ``None`` when either arm has
+        too few patients or events for a stable estimate.
+    """
+    model_df = pd.DataFrame({
+        "group": np.asarray(group).astype(int),
+        DURATION_COLUMN: np.asarray(duration, dtype=float),
+        EVENT_COLUMN: np.asarray(event, dtype=float),
+    }).dropna()
+
+    if (
+        model_df[EVENT_COLUMN].sum() < _MIN_COX_GROUP_SIZE
+        or model_df["group"].sum() < _MIN_COX_GROUP_SIZE
+        or (model_df["group"] == 0).sum() < _MIN_COX_GROUP_SIZE
+    ):
+        return None
+
+    fitted = CoxPHFitter().fit(model_df, DURATION_COLUMN, EVENT_COLUMN)
+    confidence = np.exp(fitted.confidence_intervals_.iloc[0])
+    return {
+        "hr": float(np.exp(fitted.params_["group"])),
+        "ci_lower": float(confidence.iloc[0]),
+        "ci_upper": float(confidence.iloc[1]),
+        "p": float(fitted.summary.loc["group", "p"]),
+    }
+
+
+def cox_hazard_ratios_vs_reference(
+    phenotype: pd.Series,
+    duration: pd.Series,
+    event: pd.Series,
+    reference: str = INFLAMED,
+) -> pd.DataFrame:
+    """Fit pairwise Cox models for each non-reference phenotype against the reference group.
+
+    Each comparison is restricted to the two groups involved (target vs. reference), mirroring the
+    blog's "each non-infiltrated group vs. the inflamed group" hazard ratios.
+
+    Args:
+        phenotype: IDE phenotype label per patient.
+        duration: Follow-up time per patient.
+        event: Event indicator per patient (1 = death, 0 = censored).
+        reference: The phenotype used as the reference (baseline) group.
+
+    Returns:
+        A dataframe indexed by target phenotype with columns ``hr``, ``ci_lower``, ``ci_upper`` and
+        ``p``. Comparisons with too few patients or events are omitted.
+    """
+    reference_mask = phenotype == reference
+    rows = {}
+    for target in (group for group in IDE_PHENOTYPES if group != reference):
+        target_mask = phenotype == target
+        subset = target_mask | reference_mask
+        result = cox_hazard_ratio(target_mask[subset], duration[subset], event[subset])
+        if result is not None:
+            rows[target] = result
+
+    return pd.DataFrame.from_dict(rows, orient="index", columns=["hr", "ci_lower", "ci_upper", "p"])
+
+
+def benjamini_hochberg(pvalues: pd.Series) -> pd.Series:
+    """Return Benjamini-Hochberg adjusted q-values, controlling the false-discovery rate.
+
+    Used to account for testing the immune phenotype across several indications at once.
+
+    Args:
+        pvalues: Raw p-values indexed by cohort (or any label).
+
+    Returns:
+        The adjusted q-values, aligned to the input index and clipped to at most 1.
+    """
+    ordered = pvalues.sort_values()
+    n = len(ordered)
+    ranks = np.arange(1, n + 1)
+    raw_q = ordered.to_numpy() * n / ranks
+    monotone_q = np.minimum.accumulate(raw_q[::-1])[::-1]  # enforce non-decreasing q along the ranking
+    return pd.Series(np.minimum(monotone_q, 1.0), index=ordered.index).reindex(pvalues.index)

--- a/src/aignostics_tme_studio/utils/ide.py
+++ b/src/aignostics_tme_studio/utils/ide.py
@@ -160,7 +160,7 @@ def pooled_zone_density(
 
 
 def zone_lymphocyte_density(df: pd.DataFrame, count_column: str, area_column: str) -> pd.Series:
-    """Compute per-patient lymphocyte density (cells/mm²) for a whole-tumor-region zone.
+    """Compute per-patient lymphocyte density (count / area) for a whole-tumor-region zone.
 
     A convenience for deriving density from a zone's lymphocyte count and area when a ready-made
     ``CELL_DENSITY_LYMPHOCYTE_IN_<zone>`` column is not available. Because a patient's slides are

--- a/src/aignostics_tme_studio/utils/utils.py
+++ b/src/aignostics_tme_studio/utils/utils.py
@@ -1,7 +1,7 @@
 import munch
 import yaml
 
-from .config import TISSUE_FEATURES_FILES
+from .config import TISSUE_FEATURES_FILES, WHOLE_TUMOR_REGION_CELL_FEATURES_FILES
 from .data_classes import Feature
 
 
@@ -44,3 +44,9 @@ def get_features_file_for_indication(indication: str) -> str:
     """Get features file for an indication."""
     # there are two placeholders that both are filled by the indication name.
     return TISSUE_FEATURES_FILES.format(indication, indication)
+
+
+def get_wtr_cell_features_file_for_indication(indication: str) -> str:
+    """Get the whole-tumor-region cell-features file for an indication."""
+    # both placeholders are filled by the indication name.
+    return WHOLE_TUMOR_REGION_CELL_FEATURES_FILES.format(indication, indication)

--- a/tests/aignostics_tme_studio/utils/cbioportal_test.py
+++ b/tests/aignostics_tme_studio/utils/cbioportal_test.py
@@ -1,0 +1,101 @@
+"""Unit tests for the cBioPortal survival loader."""
+
+import json
+from unittest.mock import MagicMock, patch
+
+import pytest
+import requests
+
+from aignostics_tme_studio.utils import cbioportal
+
+_STUDY = "blca_tcga_pan_can_atlas_2018"
+_MODULE = "aignostics_tme_studio.utils.cbioportal"
+
+_RECORDS = [
+    {"patientId": "TCGA-AA-0001", "clinicalAttributeId": "OS_MONTHS", "value": "12.3"},
+    {"patientId": "TCGA-AA-0001", "clinicalAttributeId": "OS_STATUS", "value": "1:DECEASED"},
+    {"patientId": "TCGA-AA-0002", "clinicalAttributeId": "OS_MONTHS", "value": "40.0"},
+    {"patientId": "TCGA-AA-0002", "clinicalAttributeId": "OS_STATUS", "value": "0:LIVING"},
+]
+
+
+def _mock_response(records: list[dict]) -> MagicMock:
+    response = MagicMock()
+    response.json.return_value = records
+    response.raise_for_status.return_value = None
+    return response
+
+
+@pytest.mark.unit
+@patch(f"{_MODULE}.requests.get")
+def test_load_survival_pivots_records(mock_get) -> None:
+    """load_survival pivots clinical records into one row per patient with survival columns."""
+    mock_get.return_value = _mock_response(_RECORDS)
+
+    result = cbioportal.load_survival([_STUDY])
+
+    assert list(result[cbioportal.PATIENT_ID_COLUMN]) == ["TCGA-AA-0001", "TCGA-AA-0002"]
+    assert cbioportal.OS_MONTHS_COLUMN in result.columns
+    assert cbioportal.OS_STATUS_COLUMN in result.columns
+    assert len(result) == 2
+
+
+@pytest.mark.unit
+@patch(f"{_MODULE}.requests.get")
+def test_load_survival_concatenates_studies(mock_get) -> None:
+    """Records from multiple studies are concatenated into one dataframe."""
+    other = [
+        {"patientId": "TCGA-BB-0003", "clinicalAttributeId": "OS_MONTHS", "value": "5.0"},
+        {"patientId": "TCGA-BB-0003", "clinicalAttributeId": "OS_STATUS", "value": "1:DECEASED"},
+    ]
+    mock_get.side_effect = [_mock_response(_RECORDS), _mock_response(other)]
+
+    result = cbioportal.load_survival([_STUDY, "lusc_tcga_pan_can_atlas_2018"])
+
+    assert len(result) == 3
+    assert "TCGA-BB-0003" in set(result[cbioportal.PATIENT_ID_COLUMN])
+
+
+@pytest.mark.unit
+@patch(f"{_MODULE}.requests.get")
+def test_load_survival_uses_and_writes_cache(mock_get, tmp_path) -> None:
+    """A cached response is written on first fetch and re-used without hitting the network again."""
+    mock_get.return_value = _mock_response(_RECORDS)
+
+    first = cbioportal.load_survival([_STUDY], cache_dir=tmp_path)
+    cache_file = tmp_path / f"{_STUDY}.json"
+    assert cache_file.exists()
+    assert json.loads(cache_file.read_text(encoding="utf-8")) == _RECORDS
+
+    mock_get.reset_mock()
+    second = cbioportal.load_survival([_STUDY], cache_dir=tmp_path)
+    mock_get.assert_not_called()
+    assert first.equals(second)
+
+
+@pytest.mark.unit
+@patch(f"{_MODULE}.time.sleep")
+@patch(f"{_MODULE}.requests.get")
+def test_request_retries_then_succeeds(mock_get, mock_sleep) -> None:
+    """A transient failure is retried before the successful response is returned."""
+    mock_get.side_effect = [requests.ConnectionError("boom"), _mock_response(_RECORDS)]
+
+    result = cbioportal.load_survival([_STUDY])
+
+    assert len(result) == 2
+    assert mock_get.call_count == 2
+    mock_sleep.assert_called_once()
+
+
+@pytest.mark.unit
+@patch(f"{_MODULE}.time.sleep")
+@patch(f"{_MODULE}.requests.get")
+def test_request_raises_after_exhausting_retries(mock_get, mock_sleep) -> None:
+    """When every attempt fails, the last exception propagates."""
+    mock_get.side_effect = requests.ConnectionError("boom")
+
+    with pytest.raises(requests.ConnectionError):
+        cbioportal.load_survival([_STUDY])
+
+    assert mock_get.call_count == 6
+    assert mock_sleep.call_count == 5

--- a/tests/aignostics_tme_studio/utils/ide_test.py
+++ b/tests/aignostics_tme_studio/utils/ide_test.py
@@ -1,0 +1,237 @@
+"""Unit tests for the IDE immune-phenotype survival analysis."""
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from aignostics_tme_studio.utils import ide
+from aignostics_tme_studio.utils.cbioportal import OS_MONTHS_COLUMN, OS_STATUS_COLUMN
+from aignostics_tme_studio.utils.config import NEOADJUVANT_COLUMN
+
+CARCINOMA = "CELL_DENSITY_LYMPHOCYTE_IN_CARCINOMA"
+STROMA = "CELL_DENSITY_LYMPHOCYTE_IN_STROMA"
+
+
+def _barcode(case: str, sample_type: str = "01") -> str:
+    return f"TCGA-AA-{case}-{sample_type}Z-00-DX1.HEX"
+
+
+@pytest.mark.unit
+def test_restrict_to_primary_tumors_keeps_only_code_01() -> None:
+    """Only primary solid tumor (sample-type 01) slides are retained."""
+    df = pd.DataFrame({
+        "TCGA_FILE_NAME": [_barcode("0001", "01"), _barcode("0002", "06"), _barcode("0003", "11")],
+    })
+
+    result = ide.restrict_to_primary_tumors(df)
+
+    assert list(result["TCGA_FILE_NAME"]) == [_barcode("0001", "01")]
+
+
+@pytest.mark.unit
+def test_aggregate_slides_to_patient_averages_numeric() -> None:
+    """Numeric features are averaged per patient; non-numeric columns take the first value."""
+    df = pd.DataFrame({
+        "TCGA_CASE_ID": ["TCGA-AA-0001", "TCGA-AA-0001", "TCGA-AA-0002"],
+        CARCINOMA: [0.2, 0.4, 1.0],
+        "TCGA_FILE_NAME": ["slide_a", "slide_b", "slide_c"],
+    })
+
+    result = ide.aggregate_slides_to_patient(df).set_index("TCGA_CASE_ID")
+
+    assert result.loc["TCGA-AA-0001", CARCINOMA] == pytest.approx(0.3)
+    assert result.loc["TCGA-AA-0002", CARCINOMA] == pytest.approx(1.0)
+    assert len(result) == 2
+
+
+@pytest.mark.unit
+def test_prepare_overall_survival_parses_and_filters() -> None:
+    """Survival is parsed into duration/event and neoadjuvant-pretreated cases are dropped."""
+    df = pd.DataFrame({
+        OS_MONTHS_COLUMN: ["12.5", "30.0", "8.0", np.nan],
+        OS_STATUS_COLUMN: ["1:DECEASED", "0:LIVING", "1:DECEASED", "0:LIVING"],
+        NEOADJUVANT_COLUMN: ["No", "Yes", "No", "No"],
+        CARCINOMA: [0.1, 0.2, 0.3, 0.4],
+    })
+
+    result = ide.prepare_overall_survival(df, [CARCINOMA])
+
+    # The neoadjuvant "Yes" row and the missing-months row are removed.
+    assert len(result) == 2
+    assert list(result[ide.EVENT_COLUMN]) == [1, 1]
+    assert list(result[ide.DURATION_COLUMN]) == [12.5, 8.0]
+
+
+@pytest.mark.unit
+def test_zone_lymphocyte_density_divides_count_by_area() -> None:
+    """Density is the lymphocyte count divided by the zone area, aligned to the input index."""
+    count_column, area_column = "CELL_COUNT_LYMPHOCYTE_IN_TUMOR_CORE", "ABSOLUTE_AREA_TUMOR_CORE"
+    df = pd.DataFrame({count_column: [100.0, 0.0], area_column: [50.0, 20.0]}, index=["p1", "p2"])
+
+    density = ide.zone_lymphocyte_density(df, count_column, area_column)
+
+    assert list(density.index) == ["p1", "p2"]
+    assert density["p1"] == pytest.approx(2.0)
+    assert density["p2"] == pytest.approx(0.0)
+
+
+@pytest.mark.unit
+def test_pooled_zone_density_area_weights_across_slides() -> None:
+    """Pooling uses summed count / summed area, not the mean of per-slide densities."""
+    count, density = "CELL_COUNT_LYMPHOCYTE_IN_TUMOR_CORE", ide.LYMPHOCYTE_DENSITY_TUMOR_CORE
+    # Patient p1: slide A (100 cells, density 10 -> area 10) + slide B (100 cells, density 100 -> area 1).
+    # Pooled = 200 / 11 = 18.18, unlike the naive mean of densities (55).
+    df = pd.DataFrame({
+        "TCGA_CASE_ID": ["p1", "p1", "p2"],
+        count: [100.0, 100.0, 0.0],
+        density: [10.0, 100.0, 0.0],
+    })
+
+    pooled = ide.pooled_zone_density(df, count, density)
+
+    assert pooled["p1"] == pytest.approx(200.0 / 11.0)
+    assert pooled["p2"] == pytest.approx(0.0)  # lymphocyte-free patient -> density 0, not NaN
+
+
+@pytest.mark.unit
+def test_pooled_zone_density_area_gate() -> None:
+    """Patients whose pooled zone area is below min_area_mm2 are dropped (NaN), except lymphocyte-free."""
+    count, density = "CELL_COUNT_LYMPHOCYTE_IN_TUMOR_CORE", ide.LYMPHOCYTE_DENSITY_TUMOR_CORE
+    # p1 area = 100/50 = 2 mm2 (below gate); p2 area = 100/10 = 10 mm2 (above); p3 lymphocyte-free.
+    df = pd.DataFrame({
+        "TCGA_CASE_ID": ["p1", "p2", "p3"],
+        count: [100.0, 100.0, 0.0],
+        density: [50.0, 10.0, 0.0],
+    })
+
+    pooled = ide.pooled_zone_density(df, count, density, min_area_mm2=5.0)
+
+    assert np.isnan(pooled["p1"])  # 2 mm2 < 5 mm2 gate -> dropped
+    assert pooled["p2"] == pytest.approx(10.0)  # 10 mm2 >= gate -> kept
+    assert pooled["p3"] == pytest.approx(0.0)  # lymphocyte-free kept as 0 despite unrecoverable area
+
+
+@pytest.mark.unit
+def test_median_thresholds_balances_non_inflamed_split() -> None:
+    """Secondary threshold is the median within the non-inflamed subset -> balanced 50/25/25."""
+    core = pd.Series([1.0, 2.0, 3.0, 4.0])  # median 2.5 -> two inflamed (3,4), two non-inflamed (1,2)
+    margin = pd.Series([10.0, 30.0, 99.0, 99.0])  # non-inflamed margins are {10,30} -> median 20
+
+    core_thr, margin_thr = ide.median_thresholds(core, margin)
+    phenotype = ide.classify_two_threshold(core, margin, core_thr, margin_thr)
+
+    assert core_thr == pytest.approx(2.5)
+    assert margin_thr == pytest.approx(20.0)  # median of {10, 30}, not of all four margins
+    assert list(phenotype) == [ide.DESERT, ide.EXCLUDED, ide.INFLAMED, ide.INFLAMED]
+
+
+@pytest.mark.unit
+def test_classify_two_threshold_applies_top_down_rule() -> None:
+    """The two-threshold rule assigns inflamed, then excluded, then desert."""
+    primary = pd.Series([2.0, 0.5, 0.5])  # core density
+    secondary = pd.Series([0.0, 2.0, 0.5])  # margin density
+
+    phenotype = ide.classify_two_threshold(primary, secondary, primary_threshold=1.0, secondary_threshold=1.0)
+
+    assert list(phenotype) == [ide.INFLAMED, ide.EXCLUDED, ide.DESERT]
+
+
+@pytest.mark.unit
+def test_prepare_overall_survival_without_neoadjuvant_column() -> None:
+    """When the neoadjuvant column is absent, no cases are dropped on that basis."""
+    df = pd.DataFrame({
+        OS_MONTHS_COLUMN: ["12.5", "30.0"],
+        OS_STATUS_COLUMN: ["1:DECEASED", "0:LIVING"],
+        CARCINOMA: [0.1, 0.2],
+    })
+
+    result = ide.prepare_overall_survival(df, [CARCINOMA])
+
+    assert len(result) == 2
+
+
+@pytest.fixture(name="cohort")
+def fixture_cohort() -> tuple[pd.Series, pd.Series, pd.Series]:
+    """A separable cohort where inflamed patients survive markedly longer than the rest."""
+    rng = np.random.default_rng(42)
+    size = 120
+    phenotype = pd.Series(np.repeat(list(ide.IDE_PHENOTYPES), size // 3))
+    # Inflamed: long times, mostly censored; others: shorter times, mostly events.
+    base = np.where(phenotype == ide.INFLAMED, 90.0, 25.0)
+    duration = pd.Series(np.clip(base + rng.normal(0, 5, size), 1, None))
+    event = pd.Series(np.where(phenotype == ide.INFLAMED, 0, 1))
+    return phenotype, duration, event
+
+
+@pytest.mark.unit
+def test_three_group_logrank_detects_separation(cohort) -> None:
+    """A strongly separated cohort yields a significant three-group log-rank p."""
+    phenotype, duration, event = cohort
+
+    p_value = ide.three_group_logrank_pvalue(duration, event, phenotype)
+
+    assert 0.0 <= p_value < 0.05
+
+
+@pytest.mark.unit
+def test_cox_hazard_ratio_binary_group(cohort) -> None:
+    """A binary high-risk group (non-inflamed) yields a hazard ratio above 1 vs. the rest."""
+    phenotype, duration, event = cohort
+    group = phenotype != ide.INFLAMED
+
+    result = ide.cox_hazard_ratio(group, duration, event)
+
+    assert result is not None
+    assert result["hr"] > 1
+    assert result["ci_lower"] <= result["hr"] <= result["ci_upper"]
+
+
+@pytest.mark.unit
+def test_cox_hazard_ratio_returns_none_for_small_group() -> None:
+    """Too small a group returns None instead of an unstable estimate."""
+    group = pd.Series([True] * 3 + [False] * 30)
+    duration = pd.Series(np.linspace(1, 100, len(group)))
+    event = pd.Series([1] * len(group))
+
+    assert ide.cox_hazard_ratio(group, duration, event) is None
+
+
+@pytest.mark.unit
+def test_cox_hazard_ratios_vs_reference(cohort) -> None:
+    """Non-inflamed groups carry hazard ratios above 1 relative to the inflamed reference."""
+    phenotype, duration, event = cohort
+
+    hazard_ratios = ide.cox_hazard_ratios_vs_reference(phenotype, duration, event)
+
+    assert set(hazard_ratios.index) == {ide.EXCLUDED, ide.DESERT}
+    assert (hazard_ratios["hr"] > 1).all()
+    assert (hazard_ratios["ci_lower"] <= hazard_ratios["hr"]).all()
+    assert (hazard_ratios["hr"] <= hazard_ratios["ci_upper"]).all()
+
+
+@pytest.mark.unit
+def test_cox_hazard_ratios_skips_small_groups() -> None:
+    """Comparisons with too few patients or events are omitted from the result."""
+    phenotype = pd.Series([ide.INFLAMED] * 20 + [ide.EXCLUDED] * 2 + [ide.DESERT] * 2)
+    duration = pd.Series(np.linspace(1, 100, len(phenotype)))
+    event = pd.Series([1] * len(phenotype))
+
+    hazard_ratios = ide.cox_hazard_ratios_vs_reference(phenotype, duration, event)
+
+    assert hazard_ratios.empty
+
+
+@pytest.mark.unit
+def test_benjamini_hochberg_matches_reference() -> None:
+    """BH q-values match a hand-computed reference and preserve the input index order."""
+    pvalues = pd.Series({"a": 0.01, "b": 0.04, "c": 0.03, "d": 0.005})
+
+    q = ide.benjamini_hochberg(pvalues)
+
+    assert list(q.index) == ["a", "b", "c", "d"]
+    # Ranked: d(0.005), a(0.01), c(0.03), b(0.04); q = p * n / rank with monotone enforcement.
+    assert q["d"] == pytest.approx(0.02)
+    assert q["a"] == pytest.approx(0.02)
+    assert q["c"] == pytest.approx(0.04)
+    assert q["b"] == pytest.approx(0.04)
+    assert (q <= 1).all()


### PR DESCRIPTION
## What

Adds a reproducible tumor-immunology analysis: build the **inflamed / excluded / desert (IDE)** phenotype from OpenTME whole-tumor-region (WTR) features and test it against overall survival across TCGA cohorts (reproduces the IDE blog post).

## Changes

**New modules**
- `utils/cbioportal.py` — fetch harmonized TCGA overall survival from the public cBioPortal API (retries + on-disk cache).
- `utils/ide.py` — primary-tumor restriction, area-weighted slides→patient pooling with a minimum-area quality gate, the two-threshold IDE rule with a balanced cut (core median, then outer-margin median **within** the non-inflamed group → 50/25/25), and three-group log-rank / pairwise Cox vs inflamed / Benjamini–Hochberg helpers.

**Config / utils**
- cBioPortal study map (8 TCGA cohorts) + `whole_tumor_region_cell_features_*` file resolver.

**Notebook (`examples/`)**
- `ide_wtr_median.py` — interactive WTR core-vs-margin IDE: draggable thresholds, comparison + follow-up controls, phenotype-shaded scatter (axis units + unit hover), Kaplan–Meier + log-rank + Cox, and a cross-cohort BH-q summary.

**Tests**
- Unit tests for `cbioportal` and `ide` (mocked API, deterministic stats).

## Validation
- `mise run lint` clean; `mise run test_unit` → 49 passing (new modules at 100%).
- Notebook loads and runs end-to-end against public OpenTME (HF) + cBioPortal.